### PR TITLE
add: .env (.env.example) to protect users and creators first Error for a friendly, easy start.

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,1 +1,1 @@
-NEXT_PUBLIC_TEMPLATE_CLIENT_ID= #xxx your create api on https://thirdweb.com/dashboard/settings/api-keys
+VITE_TEMPLATE_CLIENT_ID=#xxx your create api on https://thirdweb.com/dashboard/settings/api-keys

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+NEXT_PUBLIC_TEMPLATE_CLIENT_ID= #xxx your create api on https://thirdweb.com/dashboard/settings/api-keys

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Install the template using [thirdweb create](https://portal.thirdweb.com/cli/cre
 
 To run this project, you will need to add the following environment variables to your .env file:
 
-`CLIENT_ID`
+`CLIENT_ID` [your create api](https://thirdweb.com/dashboard/settings/api-keys).
 
 To learn how to create a client ID, refer to the [client documentation](https://portal.thirdweb.com/typescript/v5/client). 
 


### PR DESCRIPTION
**add: .env (.env.example) to protect users and creators first Error for a friendly, easy start.** 👇

![image](https://github.com/thirdweb-example/vite-starter/assets/106298826/d74c0bdf-87be-4cf1-92b6-145ccaba1130)
